### PR TITLE
Feat/crud pauta

### DIFF
--- a/src/main/java/com/sylviavitoria/api_votacao/controller/PautaController.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/controller/PautaController.java
@@ -1,5 +1,7 @@
 package com.sylviavitoria.api_votacao.controller;
 
+import java.util.Map;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -16,6 +18,11 @@ import com.sylviavitoria.api_votacao.dto.PautaRequest;
 import com.sylviavitoria.api_votacao.dto.PautaResponse;
 import com.sylviavitoria.api_votacao.interfaces.IPauta;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -23,28 +30,52 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/v1/pautas")
 @RequiredArgsConstructor
-@Tag(name = "Pautas", description = "API para gerenciamento de pautas")
+@Tag(name = "Pautas", description = "API para gerenciamento de pautas de votação")
 public class PautaController {
 
     private final IPauta iPauta;
 
+    @Operation(summary = "Criar uma nova pauta", description = "Cria uma nova pauta com os dados fornecidos")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Pauta criada com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Dados inválidos fornecidos", content = @Content(schema = @Schema(implementation = Map.class))),
+            @ApiResponse(responseCode = "404", description = "Criador não encontrado", content = @Content(schema = @Schema(implementation = Map.class)))
+    })
     @PostMapping
     public ResponseEntity<PautaResponse> criar(@RequestBody @Valid PautaRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(iPauta.criar(request));
     }
 
+    @Operation(summary = "Buscar pauta por ID", description = "Retorna uma pauta com base no ID fornecido")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Pauta encontrada com sucesso"),
+            @ApiResponse(responseCode = "404", description = "Pauta não encontrada", content = @Content(schema = @Schema(implementation = Map.class)))
+    })
     @GetMapping("/{id}")
     public ResponseEntity<PautaResponse> buscarPorId(@PathVariable Long id) {
         return ResponseEntity.ok(iPauta.buscarPorId(id));
     }
 
+    @Operation(summary = "Atualizar pauta", description = "Atualiza os dados de uma pauta existente")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Pauta atualizada com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Dados inválidos fornecidos", content = @Content(schema = @Schema(implementation = Map.class))),
+            @ApiResponse(responseCode = "404", description = "Pauta não encontrada", content = @Content(schema = @Schema(implementation = Map.class))),
+            @ApiResponse(responseCode = "409", description = "Não é possível editar uma pauta que já está em votação ou encerrada", content = @Content(schema = @Schema(implementation = Map.class)))
+    })
     @PutMapping("/{id}")
     ResponseEntity<PautaResponse> atualizar(@PathVariable Long id,
             @RequestBody @Valid PautaAtualizarRequest request) {
         return ResponseEntity.ok(iPauta.atualizar(id, request));
     }
 
+    @Operation(summary = "Excluir pauta", description = "Remove uma pauta com base no ID fornecido")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Pauta removida com sucesso"),
+            @ApiResponse(responseCode = "404", description = "Pauta não encontrada", content = @Content(schema = @Schema(implementation = Map.class))),
+            @ApiResponse(responseCode = "409", description = "Não é possível deletar uma pauta que está em votação", content = @Content(schema = @Schema(implementation = Map.class)))
+    })
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deletar(@PathVariable Long id) {
         iPauta.deletar(id);

--- a/src/main/java/com/sylviavitoria/api_votacao/controller/PautaController.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/controller/PautaController.java
@@ -1,0 +1,39 @@
+package com.sylviavitoria.api_votacao.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sylviavitoria.api_votacao.dto.PautaRequest;
+import com.sylviavitoria.api_votacao.dto.PautaResponse;
+import com.sylviavitoria.api_votacao.interfaces.IPauta;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/pautas")
+@RequiredArgsConstructor
+@Tag(name = "Pautas", description = "API para gerenciamento de pautas")
+public class PautaController {
+
+    private final IPauta iPauta;
+
+    @PostMapping
+    public ResponseEntity<PautaResponse> criar(@RequestBody @Valid PautaRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(iPauta.criar(request));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<PautaResponse> buscarPorId(@PathVariable Long id) {
+        return ResponseEntity.ok(iPauta.buscarPorId(id));
+    }
+
+}

--- a/src/main/java/com/sylviavitoria/api_votacao/controller/PautaController.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/controller/PautaController.java
@@ -2,6 +2,7 @@ package com.sylviavitoria.api_votacao.controller;
 
 import java.util.Map;
 
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.sylviavitoria.api_votacao.dto.PautaAtualizarRequest;
@@ -19,6 +21,7 @@ import com.sylviavitoria.api_votacao.dto.PautaResponse;
 import com.sylviavitoria.api_votacao.interfaces.IPauta;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -55,6 +58,20 @@ public class PautaController {
     @GetMapping("/{id}")
     public ResponseEntity<PautaResponse> buscarPorId(@PathVariable Long id) {
         return ResponseEntity.ok(iPauta.buscarPorId(id));
+    }
+
+    @GetMapping
+    @Operation(summary = "Listar todas as pautas", description = "Retorna uma lista paginada de todas as pautas cadastradas")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Operação bem-sucedida"),
+            @ApiResponse(responseCode = "500", description = "Erro interno do servidor")
+    })
+    public ResponseEntity<Page<PautaResponse>> listarTodos(
+            @Parameter(description = "Número da página (começa em 0)", example = "0") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Tamanho da página", example = "10") @RequestParam(defaultValue = "10") int size,
+            @Parameter(description = "Campo para ordenação (ex: titulo, dataCriacao, status)", example = "titulo") @RequestParam(required = false) String sort) {
+
+        return ResponseEntity.ok(iPauta.listarTodos(page, size, sort));
     }
 
     @Operation(summary = "Atualizar pauta", description = "Atualiza os dados de uma pauta existente")

--- a/src/main/java/com/sylviavitoria/api_votacao/controller/PautaController.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/controller/PautaController.java
@@ -2,13 +2,16 @@ package com.sylviavitoria.api_votacao.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.sylviavitoria.api_votacao.dto.PautaAtualizarRequest;
 import com.sylviavitoria.api_votacao.dto.PautaRequest;
 import com.sylviavitoria.api_votacao.dto.PautaResponse;
 import com.sylviavitoria.api_votacao.interfaces.IPauta;
@@ -34,6 +37,18 @@ public class PautaController {
     @GetMapping("/{id}")
     public ResponseEntity<PautaResponse> buscarPorId(@PathVariable Long id) {
         return ResponseEntity.ok(iPauta.buscarPorId(id));
+    }
+
+    @PutMapping("/{id}")
+    ResponseEntity<PautaResponse> atualizar(@PathVariable Long id,
+            @RequestBody @Valid PautaAtualizarRequest request) {
+        return ResponseEntity.ok(iPauta.atualizar(id, request));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+        iPauta.deletar(id);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/com/sylviavitoria/api_votacao/dto/AssociadoDTO.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/dto/AssociadoDTO.java
@@ -1,13 +1,17 @@
 package com.sylviavitoria.api_votacao.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Value;
 
 @Value
 @Builder
+@Schema(description = "Dados de resposta de um associado")
 public class AssociadoDTO {
-    
+
+    @Schema(description = "ID do associado", example = "1")
     private Long id;
     
+    @Schema(description = "Nome do associado", example = "João Silva")
     private String nome;
 }

--- a/src/main/java/com/sylviavitoria/api_votacao/dto/PautaAtualizarRequest.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/dto/PautaAtualizarRequest.java
@@ -1,0 +1,15 @@
+package com.sylviavitoria.api_votacao.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PautaAtualizarRequest {
+    
+    @NotBlank(message = "O título é obrigatório")
+    private String titulo;
+
+    private String descricao;
+}

--- a/src/main/java/com/sylviavitoria/api_votacao/dto/PautaAtualizarRequest.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/dto/PautaAtualizarRequest.java
@@ -1,15 +1,19 @@
 package com.sylviavitoria.api_votacao.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Schema(description = "Dados para atualização de uma pauta")
 public class PautaAtualizarRequest {
     
+    @Schema(description = "Título da pauta", example = "Assembleia Geral 2025 - Atualizada")
     @NotBlank(message = "O título é obrigatório")
     private String titulo;
 
+    @Schema(description = "Descrição detalhada da pauta", example = "Discussão sobre os resultados financeiros de 2025 e planejamento para 2026")
     private String descricao;
 }

--- a/src/main/java/com/sylviavitoria/api_votacao/dto/PautaRequest.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/dto/PautaRequest.java
@@ -1,5 +1,6 @@
 package com.sylviavitoria.api_votacao.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -7,13 +8,17 @@ import lombok.Setter;
 
 @Getter
 @Setter
+@Schema(description = "Dados para criação de uma nova pauta")
 public class PautaRequest {
     
+    @Schema(description = "Título da pauta", example = "Assembleia Geral 2025")
     @NotBlank(message = "O título é obrigatório")
     private String titulo;
     
+    @Schema(description = "Descrição detalhada da pauta", example = "Discussão sobre os resultados financeiros de 2024")
     private String descricao;
     
+    @Schema(description = "ID do associado que está criando a pauta", example = "1")
     @NotNull(message = "O ID do criador é obrigatório")
     private Long criadorId;
 }

--- a/src/main/java/com/sylviavitoria/api_votacao/dto/PautaRequest.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/dto/PautaRequest.java
@@ -1,0 +1,19 @@
+package com.sylviavitoria.api_votacao.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PautaRequest {
+    
+    @NotBlank(message = "O título é obrigatório")
+    private String titulo;
+    
+    private String descricao;
+    
+    @NotNull(message = "O ID do criador é obrigatório")
+    private Long criadorId;
+}

--- a/src/main/java/com/sylviavitoria/api_votacao/dto/PautaResponse.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/dto/PautaResponse.java
@@ -1,0 +1,25 @@
+package com.sylviavitoria.api_votacao.dto;
+
+import java.time.LocalDateTime;
+
+import com.sylviavitoria.api_votacao.enums.StatusPauta;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class PautaResponse {
+    
+    private Long id;
+    
+    private String titulo;
+    
+    private String descricao;
+    
+    private LocalDateTime dataCriacao;
+    
+    private StatusPauta status;
+    
+    private AssociadoDTO criador;
+}

--- a/src/main/java/com/sylviavitoria/api_votacao/dto/PautaResponse.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/dto/PautaResponse.java
@@ -4,22 +4,30 @@ import java.time.LocalDateTime;
 
 import com.sylviavitoria.api_votacao.enums.StatusPauta;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Value;
 
 @Value
 @Builder
+@Schema(description = "Dados de resposta de uma pauta")
 public class PautaResponse {
     
+    @Schema(description = "ID da pauta", example = "1")
     private Long id;
     
+    @Schema(description = "Título da pauta", example = "Assembleia Geral 2025")
     private String titulo;
     
+    @Schema(description = "Descrição detalhada da pauta", example = "Discussão sobre os resultados financeiros de 2025")
     private String descricao;
     
+    @Schema(description = "Data e hora de criação da pauta", example = "2025-05-15T10:30:00")
     private LocalDateTime dataCriacao;
     
+    @Schema(description = "Status atual da pauta", example = "CRIADA", allowableValues = {"CRIADA", "EM_VOTACAO", "ENCERRADA"})
     private StatusPauta status;
     
+    @Schema(description = "Informações do criador da pauta")
     private AssociadoDTO criador;
 }

--- a/src/main/java/com/sylviavitoria/api_votacao/enums/StatusPauta.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/enums/StatusPauta.java
@@ -1,0 +1,7 @@
+package com.sylviavitoria.api_votacao.enums;
+
+public enum StatusPauta {
+    CRIADA,    
+    EM_VOTACAO, 
+    ENCERRADA   
+}

--- a/src/main/java/com/sylviavitoria/api_votacao/exception/BusinessException.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/exception/BusinessException.java
@@ -1,0 +1,7 @@
+package com.sylviavitoria.api_votacao.exception;
+
+public class BusinessException extends RuntimeException {
+    public BusinessException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sylviavitoria/api_votacao/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/exception/GlobalExceptionHandler.java
@@ -56,4 +56,12 @@ public class GlobalExceptionHandler {
         errors.put("erro", "Não é possível executar esta operação devido a restrições de integridade de dados");
         return ResponseEntity.status(HttpStatus.CONFLICT).body(errors);
     }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalState(IllegalStateException ex) {
+        log.error("Estado ilegal: {}", ex.getMessage());
+        Map<String, String> errors = new HashMap<>();
+        errors.put("erro", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errors);
+    }
 }

--- a/src/main/java/com/sylviavitoria/api_votacao/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.sylviavitoria.api_votacao.exception;
 import jakarta.persistence.EntityExistsException;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -15,7 +16,6 @@ import java.util.Map;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-
 
     @ExceptionHandler(EntityNotFoundException.class)
     public ResponseEntity<Map<String, String>> handleNotFound(EntityNotFoundException ex) {
@@ -40,4 +40,20 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
     }
 
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<Map<String, String>> handleBusinessException(BusinessException ex) {
+        log.error("Erro de regra de negócio: {}", ex.getMessage());
+        Map<String, String> errors = new HashMap<>();
+        errors.put("erro", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errors);
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<Map<String, String>> handleDataIntegrityViolationException(
+            DataIntegrityViolationException ex) {
+        log.error("Erro de integridade de dados: {}", ex.getMessage());
+        Map<String, String> errors = new HashMap<>();
+        errors.put("erro", "Não é possível executar esta operação devido a restrições de integridade de dados");
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(errors);
+    }
 }

--- a/src/main/java/com/sylviavitoria/api_votacao/interfaces/IPauta.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/interfaces/IPauta.java
@@ -1,10 +1,12 @@
 package com.sylviavitoria.api_votacao.interfaces;
 
+import com.sylviavitoria.api_votacao.dto.PautaAtualizarRequest;
 import com.sylviavitoria.api_votacao.dto.PautaRequest;
 import com.sylviavitoria.api_votacao.dto.PautaResponse;
 
 public interface IPauta {
     PautaResponse criar(PautaRequest request);
     PautaResponse buscarPorId(Long id);
-    
+    PautaResponse atualizar(Long id, PautaAtualizarRequest request);
+    void deletar(Long id);
 }

--- a/src/main/java/com/sylviavitoria/api_votacao/interfaces/IPauta.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/interfaces/IPauta.java
@@ -1,5 +1,7 @@
 package com.sylviavitoria.api_votacao.interfaces;
 
+import org.springframework.data.domain.Page;
+
 import com.sylviavitoria.api_votacao.dto.PautaAtualizarRequest;
 import com.sylviavitoria.api_votacao.dto.PautaRequest;
 import com.sylviavitoria.api_votacao.dto.PautaResponse;
@@ -7,6 +9,7 @@ import com.sylviavitoria.api_votacao.dto.PautaResponse;
 public interface IPauta {
     PautaResponse criar(PautaRequest request);
     PautaResponse buscarPorId(Long id);
+    Page<PautaResponse> listarTodos(int page, int size, String sort);
     PautaResponse atualizar(Long id, PautaAtualizarRequest request);
     void deletar(Long id);
 }

--- a/src/main/java/com/sylviavitoria/api_votacao/interfaces/IPauta.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/interfaces/IPauta.java
@@ -1,0 +1,10 @@
+package com.sylviavitoria.api_votacao.interfaces;
+
+import com.sylviavitoria.api_votacao.dto.PautaRequest;
+import com.sylviavitoria.api_votacao.dto.PautaResponse;
+
+public interface IPauta {
+    PautaResponse criar(PautaRequest request);
+    PautaResponse buscarPorId(Long id);
+    
+}

--- a/src/main/java/com/sylviavitoria/api_votacao/mapper/PautaMapper.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/mapper/PautaMapper.java
@@ -1,0 +1,35 @@
+package com.sylviavitoria.api_votacao.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import com.sylviavitoria.api_votacao.dto.AssociadoDTO;
+import com.sylviavitoria.api_votacao.dto.PautaRequest;
+import com.sylviavitoria.api_votacao.dto.PautaResponse;
+import com.sylviavitoria.api_votacao.model.Associado;
+import com.sylviavitoria.api_votacao.model.Pauta;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface PautaMapper {
+    
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "dataCriacao", ignore = true)
+    @Mapping(target = "status", ignore = true)
+    @Mapping(target = "criador", ignore = true)
+    Pauta toEntity(PautaRequest request);
+    
+    @Mapping(target = "criador.id", source = "criador.id")
+    @Mapping(target = "criador.nome", source = "criador.nome")
+    PautaResponse toResponse(Pauta pauta);
+    
+    default AssociadoDTO toAssociadoDTO(Associado associado) {
+        if (associado == null) {
+            return null;
+        }
+        return AssociadoDTO.builder()
+                .id(associado.getId())
+                .nome(associado.getNome())
+                .build();
+    }
+}

--- a/src/main/java/com/sylviavitoria/api_votacao/model/Associado.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/model/Associado.java
@@ -18,10 +18,13 @@ public class Associado {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private String nome;
 
+    @Column(nullable = false, length = 11, unique = true)
     private String cpf;
 
+    @Column(nullable = false)
     private String email;
 
 }

--- a/src/main/java/com/sylviavitoria/api_votacao/model/Pauta.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/model/Pauta.java
@@ -1,0 +1,44 @@
+package com.sylviavitoria.api_votacao.model;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import com.sylviavitoria.api_votacao.enums.StatusPauta;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "tb_pautas")
+public class Pauta {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(nullable = false)
+    private String titulo;
+    
+    @Column(columnDefinition = "TEXT")
+    private String descricao;
+    
+    @CreationTimestamp
+    @Column(name = "data_criacao")
+    private LocalDateTime dataCriacao;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private StatusPauta status = StatusPauta.CRIADA;
+    
+    @ManyToOne
+    @JoinColumn(name = "criador_id", nullable = false)
+    private Associado criador;
+}

--- a/src/main/java/com/sylviavitoria/api_votacao/repository/PautaRepository.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/repository/PautaRepository.java
@@ -1,0 +1,11 @@
+package com.sylviavitoria.api_votacao.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.sylviavitoria.api_votacao.model.Pauta;
+
+@Repository
+public interface PautaRepository extends JpaRepository<Pauta, Long> {
+    boolean existsByCriadorId(Long criadorId);
+}

--- a/src/main/java/com/sylviavitoria/api_votacao/service/AssociadoService.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/service/AssociadoService.java
@@ -7,6 +7,8 @@ import com.sylviavitoria.api_votacao.interfaces.IAssociado;
 import com.sylviavitoria.api_votacao.mapper.AssociadoMapper;
 import com.sylviavitoria.api_votacao.model.Associado;
 import com.sylviavitoria.api_votacao.repository.AssociadoRepository;
+import com.sylviavitoria.api_votacao.repository.PautaRepository;
+
 import jakarta.persistence.EntityExistsException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +20,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.sylviavitoria.api_votacao.exception.BusinessException;
 import com.sylviavitoria.api_votacao.exception.EntityNotFoundException;
 
 @Slf4j
@@ -27,6 +30,7 @@ public class AssociadoService implements IAssociado {
 
     private final AssociadoRepository associadoRepository;
     private final AssociadoMapper associadoMapper;
+    private final PautaRepository pautaRepository;
 
     @Override
     @Transactional
@@ -90,6 +94,10 @@ public class AssociadoService implements IAssociado {
         Associado associado = associadoRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Associado não encontrado"));
 
+        if (pautaRepository.existsByCriadorId(id)) {
+        throw new BusinessException("Não é possível excluir um associado que possui pautas vinculadas");
+        }
+        
         associadoRepository.delete(associado);
     }
 }

--- a/src/main/java/com/sylviavitoria/api_votacao/service/PautaService.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/service/PautaService.java
@@ -1,0 +1,57 @@
+package com.sylviavitoria.api_votacao.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sylviavitoria.api_votacao.dto.PautaRequest;
+import com.sylviavitoria.api_votacao.dto.PautaResponse;
+import com.sylviavitoria.api_votacao.enums.StatusPauta;
+import com.sylviavitoria.api_votacao.exception.EntityNotFoundException;
+import com.sylviavitoria.api_votacao.interfaces.IPauta;
+import com.sylviavitoria.api_votacao.mapper.PautaMapper;
+import com.sylviavitoria.api_votacao.model.Associado;
+import com.sylviavitoria.api_votacao.model.Pauta;
+import com.sylviavitoria.api_votacao.repository.AssociadoRepository;
+import com.sylviavitoria.api_votacao.repository.PautaRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PautaService implements IPauta {
+
+    private final PautaRepository pautaRepository;
+    private final AssociadoRepository associadoRepository;
+    private final PautaMapper pautaMapper;
+
+    @Override
+    @Transactional
+    public PautaResponse criar(PautaRequest request) {
+        log.info("Iniciando criação de pauta: {}, criador: {}", request.getTitulo(), request.getCriadorId());
+
+        Associado criador = associadoRepository.findById(request.getCriadorId())
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "Associado não encontrado com ID: " + request.getCriadorId()));
+
+        Pauta pauta = pautaMapper.toEntity(request);
+        pauta.setCriador(criador);
+        pauta.setStatus(StatusPauta.CRIADA);
+
+        Pauta pautaSalva = pautaRepository.save(pauta);
+        log.info("Pauta criada com sucesso: ID {}", pautaSalva.getId());
+
+        return pautaMapper.toResponse(pautaSalva);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PautaResponse buscarPorId(Long id) {
+        log.info("Buscando pauta por ID: {}", id);
+        Pauta pauta = pautaRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Pauta não encontrada com ID: " + id));
+
+        return pautaMapper.toResponse(pauta);
+    }
+}

--- a/src/main/java/com/sylviavitoria/api_votacao/service/PautaService.java
+++ b/src/main/java/com/sylviavitoria/api_votacao/service/PautaService.java
@@ -1,5 +1,9 @@
 package com.sylviavitoria.api_votacao.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,6 +59,22 @@ public class PautaService implements IPauta {
                 .orElseThrow(() -> new EntityNotFoundException("Pauta não encontrada com ID: " + id));
 
         return pautaMapper.toResponse(pauta);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<PautaResponse> listarTodos(int page, int size, String sort) {
+        log.info("Listando pauta com paginação: página {}, tamanho {}, ordenação {}", page, size, sort);
+
+        Pageable pageable;
+        if (sort != null && !sort.isEmpty()) {
+            pageable = PageRequest.of(page, size, Sort.by(sort));
+        } else {
+            pageable = PageRequest.of(page, size, Sort.by("titulo"));
+        }
+
+            return pautaRepository.findAll(pageable)  
+            .map(pautaMapper::toResponse); 
     }
 
     @Override

--- a/src/test/java/com/sylviavitoria/api_votacao/controller/PautaControllerTest.java
+++ b/src/test/java/com/sylviavitoria/api_votacao/controller/PautaControllerTest.java
@@ -1,0 +1,331 @@
+package com.sylviavitoria.api_votacao.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sylviavitoria.api_votacao.dto.AssociadoDTO;
+import com.sylviavitoria.api_votacao.dto.PautaAtualizarRequest;
+import com.sylviavitoria.api_votacao.dto.PautaRequest;
+import com.sylviavitoria.api_votacao.dto.PautaResponse;
+import com.sylviavitoria.api_votacao.enums.StatusPauta;
+import com.sylviavitoria.api_votacao.exception.BusinessException;
+import com.sylviavitoria.api_votacao.exception.EntityNotFoundException;
+import com.sylviavitoria.api_votacao.exception.GlobalExceptionHandler;
+import com.sylviavitoria.api_votacao.interfaces.IPauta;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest({ PautaController.class, GlobalExceptionHandler.class })
+public class PautaControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private IPauta iPauta;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private PautaRequest pautaRequest;
+    private PautaResponse pautaResponse;
+    private PautaAtualizarRequest pautaAtualizarRequest;
+    private LocalDateTime dataCriacao;
+
+    @BeforeEach
+    void setUp() {
+        dataCriacao = LocalDateTime.now();
+
+        pautaRequest = new PautaRequest();
+        pautaRequest.setTitulo("Assembleia Geral 2025");
+        pautaRequest.setDescricao("Discussão sobre os resultados financeiros de 2024");
+        pautaRequest.setCriadorId(1L);
+
+        AssociadoDTO criador = AssociadoDTO.builder()
+                .id(1L)
+                .nome("João da Silva")
+                .build();
+
+        pautaResponse = PautaResponse.builder()
+                .id(1L)
+                .titulo("Assembleia Geral 2025")
+                .descricao("Discussão sobre os resultados financeiros de 2024")
+                .dataCriacao(dataCriacao)
+                .status(StatusPauta.CRIADA)
+                .criador(criador)
+                .build();
+
+        pautaAtualizarRequest = new PautaAtualizarRequest();
+        pautaAtualizarRequest.setTitulo("Assembleia Geral 2025 - Atualizada");
+        pautaAtualizarRequest.setDescricao("Discussão atualizada sobre os resultados financeiros de 2024");
+
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new PautaController(iPauta))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter())
+                .build();
+    }
+
+    @Test
+    @DisplayName("Deve criar uma pauta com sucesso")
+    void criarPautaSucesso() throws Exception {
+
+        ArgumentCaptor<PautaRequest> requestCaptor = ArgumentCaptor.forClass(PautaRequest.class);
+
+        when(iPauta.criar(requestCaptor.capture())).thenReturn(pautaResponse);
+
+        mockMvc.perform(post("/api/v1/pautas")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(pautaRequest)))
+                .andDo(print())
+                .andExpect(status().isCreated());
+
+        PautaRequest capturedRequest = requestCaptor.getValue();
+        assertEquals(pautaRequest.getTitulo(), capturedRequest.getTitulo());
+        assertEquals(pautaRequest.getDescricao(), capturedRequest.getDescricao());
+        assertEquals(pautaRequest.getCriadorId(), capturedRequest.getCriadorId());
+
+        verify(iPauta).criar(capturedRequest);
+        verifyNoMoreInteractions(iPauta);
+    }
+
+    @Test
+    @DisplayName("Deve retornar not found quando criar pauta com criador inexistente")
+    void criarPautaCriadorInexistente() throws Exception {
+
+        when(iPauta.criar(argThat(request -> request.getTitulo().equals(pautaRequest.getTitulo()) &&
+                request.getDescricao().equals(pautaRequest.getDescricao()) &&
+                request.getCriadorId().equals(pautaRequest.getCriadorId())))).thenThrow(
+                        new EntityNotFoundException("Associado não encontrado com ID: " + pautaRequest.getCriadorId()));
+
+        mockMvc.perform(post("/api/v1/pautas")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(pautaRequest)))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.erro").value("Associado não encontrado com ID: " + pautaRequest.getCriadorId()));
+
+        verify(iPauta).criar(argThat(request -> request.getTitulo().equals(pautaRequest.getTitulo()) &&
+                request.getDescricao().equals(pautaRequest.getDescricao()) &&
+                request.getCriadorId().equals(pautaRequest.getCriadorId())));
+        verifyNoMoreInteractions(iPauta);
+    }
+
+    @Test
+    @DisplayName("Deve buscar pauta por ID com sucesso")
+    void buscarPautaPorIdSucesso() throws Exception {
+        Long id = 1L;
+        when(iPauta.buscarPorId(id)).thenReturn(pautaResponse);
+
+        mockMvc.perform(get("/api/v1/pautas/{id}", id))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        verify(iPauta).buscarPorId(id);
+        verifyNoMoreInteractions(iPauta);
+    }
+
+    @Test
+    @DisplayName("Deve retornar not found quando buscar pauta com ID inexistente")
+    void buscarPautaPorIdInexistente() throws Exception {
+        Long id = 99L;
+        when(iPauta.buscarPorId(id)).thenThrow(new EntityNotFoundException("Pauta não encontrada com ID: " + id));
+
+        mockMvc.perform(get("/api/v1/pautas/{id}", id))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.erro").value("Pauta não encontrada com ID: " + id));
+
+        verify(iPauta).buscarPorId(id);
+        verifyNoMoreInteractions(iPauta);
+    }
+
+    @Test
+    @DisplayName("Deve listar todas as pautas com sucesso")
+    void listarTodasPautasSucesso() throws Exception {
+        int page = 0;
+        int size = 10;
+        String sort = "titulo";
+
+        List<PautaResponse> content = List.of(pautaResponse);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(sort));
+        Page<PautaResponse> pageResponse = new PageImpl<>(content, pageable, content.size());
+
+        when(iPauta.listarTodos(page, size, sort)).thenReturn(pageResponse);
+
+        mockMvc.perform(get("/api/v1/pautas")
+                .param("page", String.valueOf(page))
+                .param("size", String.valueOf(size))
+                .param("sort", sort))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        verify(iPauta).listarTodos(page, size, sort);
+        verifyNoMoreInteractions(iPauta);
+    }
+
+    @Test
+    @DisplayName("Deve atualizar uma pauta com sucesso")
+    void atualizarPautaSucesso() throws Exception {
+        Long id = 1L;
+        ArgumentCaptor<Long> idCaptor = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<PautaAtualizarRequest> requestCaptor = ArgumentCaptor.forClass(PautaAtualizarRequest.class);
+
+        PautaResponse responseAtualizado = PautaResponse.builder()
+                .id(id)
+                .titulo(pautaAtualizarRequest.getTitulo())
+                .descricao(pautaAtualizarRequest.getDescricao())
+                .dataCriacao(dataCriacao)
+                .status(StatusPauta.CRIADA)
+                .criador(pautaResponse.getCriador())
+                .build();
+
+        when(iPauta.atualizar(idCaptor.capture(), requestCaptor.capture())).thenReturn(responseAtualizado);
+
+        mockMvc.perform(put("/api/v1/pautas/{id}", id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(pautaAtualizarRequest)))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        assertEquals(id, idCaptor.getValue());
+        assertEquals(pautaAtualizarRequest.getTitulo(), requestCaptor.getValue().getTitulo());
+        assertEquals(pautaAtualizarRequest.getDescricao(), requestCaptor.getValue().getDescricao());
+
+        verify(iPauta).atualizar(eq(id),
+                argThat(request -> request.getTitulo().equals(pautaAtualizarRequest.getTitulo()) &&
+                        request.getDescricao().equals(pautaAtualizarRequest.getDescricao())));
+        verifyNoMoreInteractions(iPauta);
+    }
+
+    @Test
+    @DisplayName("Deve retornar not found quando atualizar pauta inexistente")
+    void atualizarPautaInexistente() throws Exception {
+        Long id = 99L;
+
+        when(iPauta.atualizar(eq(id),
+                argThat(request -> request.getTitulo().equals(pautaAtualizarRequest.getTitulo()) &&
+                        request.getDescricao().equals(pautaAtualizarRequest.getDescricao()))))
+                .thenThrow(new EntityNotFoundException("Pauta não encontrada com ID: " + id));
+
+        mockMvc.perform(put("/api/v1/pautas/{id}", id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(pautaAtualizarRequest)))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.erro").value("Pauta não encontrada com ID: " + id));
+
+        verify(iPauta).atualizar(eq(id),
+                argThat(request -> request.getTitulo().equals(pautaAtualizarRequest.getTitulo()) &&
+                        request.getDescricao().equals(pautaAtualizarRequest.getDescricao())));
+        verifyNoMoreInteractions(iPauta);
+    }
+
+    @Test
+    @DisplayName("Deve retornar conflict quando tentar atualizar pauta em votação")
+    void atualizarPautaEmVotacao() throws Exception {
+        Long id = 1L;
+
+        when(iPauta.atualizar(eq(id),
+                argThat(request -> request.getTitulo().equals(pautaAtualizarRequest.getTitulo()) &&
+                        request.getDescricao().equals(pautaAtualizarRequest.getDescricao()))))
+                .thenThrow(
+                        new BusinessException("Não é possível editar uma pauta que já está em votação ou encerrada"));
+
+        mockMvc.perform(put("/api/v1/pautas/{id}", id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(pautaAtualizarRequest)))
+                .andDo(print())
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.erro")
+                        .value("Não é possível editar uma pauta que já está em votação ou encerrada"));
+
+        verify(iPauta).atualizar(eq(id),
+                argThat(request -> request.getTitulo().equals(pautaAtualizarRequest.getTitulo()) &&
+                        request.getDescricao().equals(pautaAtualizarRequest.getDescricao())));
+        verifyNoMoreInteractions(iPauta);
+    }
+
+    @Test
+    @DisplayName("Deve deletar uma pauta com sucesso")
+    void deletarPautaSucesso() throws Exception {
+        Long id = 1L;
+        doNothing().when(iPauta).deletar(id);
+
+        mockMvc.perform(delete("/api/v1/pautas/{id}", id))
+                .andDo(print())
+                .andExpect(status().isNoContent());
+
+        verify(iPauta).deletar(id);
+        verifyNoMoreInteractions(iPauta);
+    }
+
+    @Test
+    @DisplayName("Deve retornar not found quando deletar pauta inexistente")
+    void deletarPautaInexistente() throws Exception {
+        Long id = 99L;
+        doThrow(new EntityNotFoundException("Pauta não encontrada com ID: " + id))
+                .when(iPauta).deletar(id);
+
+        mockMvc.perform(delete("/api/v1/pautas/{id}", id))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.erro").value("Pauta não encontrada com ID: " + id));
+
+        verify(iPauta).deletar(id);
+        verifyNoMoreInteractions(iPauta);
+    }
+
+    @Test
+    @DisplayName("Deve retornar conflict quando deletar pauta em votação")
+    void deletarPautaEmVotacao() throws Exception {
+        Long id = 1L;
+        doThrow(new IllegalStateException("Não é possível deletar uma pauta que está em votação"))
+                .when(iPauta).deletar(id);
+
+        mockMvc.perform(delete("/api/v1/pautas/{id}", id))
+                .andDo(print())
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.erro").value("Não é possível deletar uma pauta que está em votação"));
+
+        verify(iPauta).deletar(id);
+        verifyNoMoreInteractions(iPauta);
+    }
+
+    @Test
+    @DisplayName("Deve retornar bad request quando criar pauta com dados inválidos")
+    void criarPautaDadosInvalidos() throws Exception {
+        PautaRequest invalido = new PautaRequest();
+
+        mockMvc.perform(post("/api/v1/pautas")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(invalido)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(iPauta);
+    }
+}

--- a/src/test/java/com/sylviavitoria/api_votacao/service/AsssociadoServiceTest.java
+++ b/src/test/java/com/sylviavitoria/api_votacao/service/AsssociadoServiceTest.java
@@ -7,6 +7,8 @@ import com.sylviavitoria.api_votacao.exception.EntityNotFoundException;
 import com.sylviavitoria.api_votacao.mapper.AssociadoMapper;
 import com.sylviavitoria.api_votacao.model.Associado;
 import com.sylviavitoria.api_votacao.repository.AssociadoRepository;
+import com.sylviavitoria.api_votacao.repository.PautaRepository;
+
 import jakarta.persistence.EntityExistsException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -32,6 +34,9 @@ public class AsssociadoServiceTest {
     
     @Mock
     private AssociadoMapper associadoMapper;
+
+    @Mock 
+    private PautaRepository pautaRepository;
     
     @InjectMocks
     private AssociadoService associadoService;
@@ -242,16 +247,17 @@ public class AsssociadoServiceTest {
     @Test
     @DisplayName("Deve deletar um associado com sucesso")
     void deletarAssociadoSucesso() {
-
         Long id = 1L;
         when(associadoRepository.findById(id)).thenReturn(Optional.of(associado));
+        when(pautaRepository.existsByCriadorId(id)).thenReturn(false);
         doNothing().when(associadoRepository).delete(associado);
-        
+    
         associadoService.deletar(id);
-        
+    
         verify(associadoRepository).findById(id);
+        verify(pautaRepository).existsByCriadorId(id);
         verify(associadoRepository).delete(associado);
-        verifyNoMoreInteractions(associadoRepository);
+        verifyNoMoreInteractions(associadoRepository, pautaRepository);
         verifyNoInteractions(associadoMapper);
     }
     

--- a/src/test/java/com/sylviavitoria/api_votacao/service/PautaServiceTest.java
+++ b/src/test/java/com/sylviavitoria/api_votacao/service/PautaServiceTest.java
@@ -1,0 +1,343 @@
+package com.sylviavitoria.api_votacao.service;
+
+import com.sylviavitoria.api_votacao.dto.AssociadoDTO;
+import com.sylviavitoria.api_votacao.dto.PautaAtualizarRequest;
+import com.sylviavitoria.api_votacao.dto.PautaRequest;
+import com.sylviavitoria.api_votacao.dto.PautaResponse;
+import com.sylviavitoria.api_votacao.enums.StatusPauta;
+import com.sylviavitoria.api_votacao.exception.BusinessException;
+import com.sylviavitoria.api_votacao.exception.EntityNotFoundException;
+import com.sylviavitoria.api_votacao.mapper.PautaMapper;
+import com.sylviavitoria.api_votacao.model.Associado;
+import com.sylviavitoria.api_votacao.model.Pauta;
+import com.sylviavitoria.api_votacao.repository.AssociadoRepository;
+import com.sylviavitoria.api_votacao.repository.PautaRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.*;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class PautaServiceTest {
+    
+    @Mock
+    private PautaRepository pautaRepository;
+    
+    @Mock
+    private AssociadoRepository associadoRepository;
+    
+    @Mock
+    private PautaMapper pautaMapper;
+    
+    @InjectMocks
+    private PautaService pautaService;
+    
+    private PautaRequest pautaRequest;
+    private Pauta pauta;
+    private Associado associado;
+    private PautaResponse pautaResponse;
+    private PautaAtualizarRequest pautaAtualizarRequest;
+    
+    @BeforeEach
+    void setUp() {
+
+        associado = new Associado();
+        associado.setId(1L);
+        associado.setNome("João da Silva");
+        associado.setCpf("12345678901");
+        associado.setEmail("joao@exemplo.com");
+        
+        pautaRequest = new PautaRequest();
+        pautaRequest.setTitulo("Assembleia Geral 2025");
+        pautaRequest.setDescricao("Discussão sobre os resultados financeiros de 2024");
+        pautaRequest.setCriadorId(1L);
+        
+        pauta = new Pauta();
+        pauta.setId(1L);
+        pauta.setTitulo("Assembleia Geral 2025");
+        pauta.setDescricao("Discussão sobre os resultados financeiros de 2024");
+        pauta.setCriador(associado);
+        pauta.setStatus(StatusPauta.CRIADA);
+        pauta.setDataCriacao(LocalDateTime.now());
+        
+        AssociadoDTO associadoDTO = AssociadoDTO.builder()
+                .id(1L)
+                .nome("João da Silva")
+                .build();
+        
+        pautaResponse = PautaResponse.builder()
+                .id(1L)
+                .titulo("Assembleia Geral 2025")
+                .descricao("Discussão sobre os resultados financeiros de 2024")
+                .status(StatusPauta.CRIADA)
+                .dataCriacao(pauta.getDataCriacao())
+                .criador(associadoDTO)
+                .build();
+        
+        pautaAtualizarRequest = new PautaAtualizarRequest();
+        pautaAtualizarRequest.setTitulo("Assembleia Geral 2025 - Atualizada");
+        pautaAtualizarRequest.setDescricao("Discussão atualizada sobre os resultados financeiros de 2024");
+    }
+    
+    @Test
+    @DisplayName("Deve criar uma pauta com sucesso")
+    void criarPautaSucesso() {
+        when(associadoRepository.findById(pautaRequest.getCriadorId())).thenReturn(Optional.of(associado));
+        when(pautaMapper.toEntity(pautaRequest)).thenReturn(pauta);
+        when(pautaRepository.save(pauta)).thenReturn(pauta);
+        when(pautaMapper.toResponse(pauta)).thenReturn(pautaResponse);
+        
+        PautaResponse resultado = pautaService.criar(pautaRequest);
+        
+        assertNotNull(resultado);
+        assertEquals(pautaRequest.getTitulo(), resultado.getTitulo());
+        assertEquals(pautaRequest.getDescricao(), resultado.getDescricao());
+        assertEquals(StatusPauta.CRIADA, resultado.getStatus());
+        assertEquals(associado.getId(), resultado.getCriador().getId());
+        
+        verify(associadoRepository).findById(pautaRequest.getCriadorId());
+        verify(pautaMapper).toEntity(pautaRequest);
+        verify(pautaRepository).save(pauta);
+        verify(pautaMapper).toResponse(pauta);
+        verifyNoMoreInteractions(pautaRepository, associadoRepository, pautaMapper);
+    }
+    
+    @Test
+    @DisplayName("Deve lançar exceção ao criar pauta com criador inexistente")
+    void criarPautaCriadorInexistente() {
+        when(associadoRepository.findById(pautaRequest.getCriadorId())).thenReturn(Optional.empty());
+        
+        EntityNotFoundException exception = assertThrows(EntityNotFoundException.class, () -> {
+            pautaService.criar(pautaRequest);
+        });
+        
+        assertEquals("Associado não encontrado com ID: " + pautaRequest.getCriadorId(), exception.getMessage());
+        verify(associadoRepository).findById(pautaRequest.getCriadorId());
+        verifyNoInteractions(pautaMapper, pautaRepository);
+        verifyNoMoreInteractions(associadoRepository);
+    }
+    
+    @Test
+    @DisplayName("Deve buscar pauta por ID com sucesso")
+    void buscarPorIdSucesso() {
+        Long id = 1L;
+        when(pautaRepository.findById(id)).thenReturn(Optional.of(pauta));
+        when(pautaMapper.toResponse(pauta)).thenReturn(pautaResponse);
+        
+        PautaResponse resultado = pautaService.buscarPorId(id);
+        
+        assertNotNull(resultado);
+        assertEquals(pauta.getId(), resultado.getId());
+        assertEquals(pauta.getTitulo(), resultado.getTitulo());
+        assertEquals(pauta.getDescricao(), resultado.getDescricao());
+        assertEquals(pauta.getStatus(), resultado.getStatus());
+        
+        verify(pautaRepository).findById(id);
+        verify(pautaMapper).toResponse(pauta);
+        verifyNoMoreInteractions(pautaRepository, pautaMapper);
+        verifyNoInteractions(associadoRepository);
+    }
+    
+    @Test
+    @DisplayName("Deve lançar exceção ao buscar pauta com ID inexistente")
+    void buscarPorIdInexistente() {
+        Long id = 99L;
+        when(pautaRepository.findById(id)).thenReturn(Optional.empty());
+        
+        EntityNotFoundException exception = assertThrows(EntityNotFoundException.class, () -> {
+            pautaService.buscarPorId(id);
+        });
+        
+        assertEquals("Pauta não encontrada com ID: " + id, exception.getMessage());
+        verify(pautaRepository).findById(id);
+        verifyNoMoreInteractions(pautaRepository);
+        verifyNoInteractions(pautaMapper, associadoRepository);
+    }
+    
+    @Test
+    @DisplayName("Deve listar todas as pautas com paginação e sort")
+    void listarTodosComPaginacaoESort() {
+        int page = 0;
+        int size = 10;
+        String sort = "titulo";
+        Pageable pageable = PageRequest.of(page, size, Sort.by(sort));
+        
+        List<Pauta> pautas = Arrays.asList(pauta);
+        Page<Pauta> pagePautas = new PageImpl<>(pautas, pageable, pautas.size());
+        
+        when(pautaRepository.findAll(pageable)).thenReturn(pagePautas);
+        when(pautaMapper.toResponse(pauta)).thenReturn(pautaResponse);
+        
+        Page<PautaResponse> resultado = pautaService.listarTodos(page, size, sort);
+        
+        assertNotNull(resultado);
+        assertEquals(1, resultado.getTotalElements());
+        assertEquals(1, resultado.getContent().size());
+        
+        verify(pautaRepository).findAll(pageable);
+        verify(pautaMapper).toResponse(pauta);
+        verifyNoMoreInteractions(pautaRepository, pautaMapper);
+        verifyNoInteractions(associadoRepository);
+    }
+    
+    @Test
+    @DisplayName("Deve listar todas as pautas sem informar sort (usando default)")
+    void listarTodosComPaginacaoSemSort() {
+        int page = 0;
+        int size = 10;
+        String sort = null;
+        Pageable pageable = PageRequest.of(page, size, Sort.by("titulo"));
+        
+        List<Pauta> pautas = Arrays.asList(pauta);
+        Page<Pauta> pagePautas = new PageImpl<>(pautas, pageable, pautas.size());
+        
+        when(pautaRepository.findAll(pageable)).thenReturn(pagePautas);
+        when(pautaMapper.toResponse(pauta)).thenReturn(pautaResponse);
+        
+        Page<PautaResponse> resultado = pautaService.listarTodos(page, size, sort);
+        
+        assertNotNull(resultado);
+        assertEquals(1, resultado.getTotalElements());
+        assertEquals(1, resultado.getContent().size());
+        
+        verify(pautaRepository).findAll(pageable);
+        verify(pautaMapper).toResponse(pauta);
+        verifyNoMoreInteractions(pautaRepository, pautaMapper);
+        verifyNoInteractions(associadoRepository);
+    }
+    
+    @Test
+    @DisplayName("Deve atualizar uma pauta com sucesso")
+    void atualizarPautaSucesso() {
+        Long id = 1L;
+        Pauta pautaAtualizada = new Pauta();
+        pautaAtualizada.setId(id);
+        pautaAtualizada.setTitulo(pautaAtualizarRequest.getTitulo());
+        pautaAtualizada.setDescricao(pautaAtualizarRequest.getDescricao());
+        pautaAtualizada.setStatus(StatusPauta.CRIADA);
+        pautaAtualizada.setCriador(associado);
+        pautaAtualizada.setDataCriacao(pauta.getDataCriacao());
+        
+        PautaResponse responseAtualizado = PautaResponse.builder()
+                .id(id)
+                .titulo(pautaAtualizarRequest.getTitulo())
+                .descricao(pautaAtualizarRequest.getDescricao())
+                .status(StatusPauta.CRIADA)
+                .dataCriacao(pauta.getDataCriacao())
+                .criador(pautaResponse.getCriador())
+                .build();
+        
+        when(pautaRepository.findById(id)).thenReturn(Optional.of(pauta));
+        when(pautaRepository.save(pauta)).thenReturn(pautaAtualizada);
+        when(pautaMapper.toResponse(pautaAtualizada)).thenReturn(responseAtualizado);
+        
+        PautaResponse resultado = pautaService.atualizar(id, pautaAtualizarRequest);
+        
+        assertNotNull(resultado);
+        assertEquals(pautaAtualizarRequest.getTitulo(), resultado.getTitulo());
+        assertEquals(pautaAtualizarRequest.getDescricao(), resultado.getDescricao());
+        assertEquals(StatusPauta.CRIADA, resultado.getStatus());
+        
+        verify(pautaRepository).findById(id);
+        verify(pautaRepository).save(pauta);
+        verify(pautaMapper).toResponse(pautaAtualizada);
+        verifyNoMoreInteractions(pautaRepository, pautaMapper);
+        verifyNoInteractions(associadoRepository);
+    }
+    
+    @Test
+    @DisplayName("Deve lançar exceção ao atualizar pauta com ID inexistente")
+    void atualizarPautaInexistente() {
+        Long id = 99L;
+        when(pautaRepository.findById(id)).thenReturn(Optional.empty());
+        
+        EntityNotFoundException exception = assertThrows(EntityNotFoundException.class, () -> {
+            pautaService.atualizar(id, pautaAtualizarRequest);
+        });
+        
+        assertEquals("Pauta não encontrada com ID: " + id, exception.getMessage());
+        verify(pautaRepository).findById(id);
+        verifyNoMoreInteractions(pautaRepository);
+        verifyNoInteractions(pautaMapper, associadoRepository);
+    }
+    
+    @Test
+    @DisplayName("Deve lançar exceção ao atualizar pauta que não está no status CRIADA")
+    void atualizarPautaNaoEditavel() {
+        Long id = 1L;
+        pauta.setStatus(StatusPauta.EM_VOTACAO);
+        
+        when(pautaRepository.findById(id)).thenReturn(Optional.of(pauta));
+        
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            pautaService.atualizar(id, pautaAtualizarRequest);
+        });
+        
+        assertEquals("Não é possível editar uma pauta que já está em votação ou encerrada", exception.getMessage());
+        verify(pautaRepository).findById(id);
+        verifyNoMoreInteractions(pautaRepository);
+        verifyNoInteractions(pautaMapper, associadoRepository);
+    }
+    
+    @Test
+    @DisplayName("Deve deletar uma pauta com sucesso")
+    void deletarPautaSucesso() {
+        Long id = 1L;
+        when(pautaRepository.findById(id)).thenReturn(Optional.of(pauta));
+        doNothing().when(pautaRepository).delete(pauta);
+        
+        pautaService.deletar(id);
+        
+        verify(pautaRepository).findById(id);
+        verify(pautaRepository).delete(pauta);
+        verifyNoMoreInteractions(pautaRepository);
+        verifyNoInteractions(pautaMapper, associadoRepository);
+    }
+    
+    @Test
+    @DisplayName("Deve lançar exceção ao deletar pauta com ID inexistente")
+    void deletarPautaInexistente() {
+        Long id = 99L;
+        when(pautaRepository.findById(id)).thenReturn(Optional.empty());
+        
+        EntityNotFoundException exception = assertThrows(EntityNotFoundException.class, () -> {
+            pautaService.deletar(id);
+        });
+        
+        assertEquals("Pauta não encontrada com ID: " + id, exception.getMessage());
+        verify(pautaRepository).findById(id);
+        verifyNoMoreInteractions(pautaRepository);
+        verifyNoInteractions(pautaMapper, associadoRepository);
+    }
+    
+    @Test
+    @DisplayName("Deve lançar exceção ao deletar pauta que está em votação")
+    void deletarPautaEmVotacao() {
+        Long id = 1L;
+        pauta.setStatus(StatusPauta.EM_VOTACAO);
+        
+        when(pautaRepository.findById(id)).thenReturn(Optional.of(pauta));
+        
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> {
+            pautaService.deletar(id);
+        });
+        
+        assertEquals("Não é possível deletar uma pauta que está em votação", exception.getMessage());
+        verify(pautaRepository).findById(id);
+        verifyNoMoreInteractions(pautaRepository);
+        verifyNoInteractions(pautaMapper, associadoRepository);
+    }
+}


### PR DESCRIPTION
# 📍 CRUD Pauta #4 

## 📌 Descrição
Este pull request apresenta uma implementação abrangente para o gerenciamento de "pautas" na aplicação. Inclui a adição de um novo `PautaController`, que suporta DTOs, interfaces de serviço, tratamento de exceções e integração com banco de dados. As alterações são agrupadas em três temas principais: funcionalidade da API, modelagem de dados e tratamento de exceções.

### Funcionalidade da API
* Adicionado `PautaController` para lidar com operações CRUD para "pautas", incluindo endpoints para criar, recuperar, atualizar e excluir agendas. Cada endpoint é documentado com anotações do Swagger para melhor documentação da API.
* Criada a interface `IPauta` para definir o contrato da camada de serviço para "pautas", incluindo métodos para operações CRUD.

### Modelagem de Dados
* Adicionadas as classes `Pauta`, `PautaRequest`, `PautaAtualizarRequest` e `PautaResponse` para representar os modelos de entidade, solicitação e resposta para "pautas". Isso inclui anotações de validação e metadados Swagger para documentação.
* Introduzida a enumeração `StatusPauta` para definir os possíveis status de uma "pauta" (por exemplo, "CRIADA", "EM_VOTACAO", "ENCERRADA").
* Atualizado o modelo `Associado` para incluir novos campos (`cpf`, `email`) com restrições de validação.

### Tratamento de Exceções
* Adicionada a classe `BusinessException` para tratar violações de regras de negócios.
* Aprimorado o `GlobalExceptionHandler` para tratar `BusinessException`, `DataIntegrityViolationException` e `IllegalStateException`, fornecendo respostas de erro significativas.

* `AssociadoService` atualizado para evitar a exclusão de um `Associado` com "pautas" vinculados, gerando uma `BusinessException` se tal caso ocorrer.